### PR TITLE
Make compiler vars cached vars

### DIFF
--- a/toolchain/iOS.cmake
+++ b/toolchain/iOS.cmake
@@ -46,8 +46,8 @@ if (CMAKE_UNAME)
 endif (CMAKE_UNAME)
 
 # Force the compilers to gcc for iOS
-set (CMAKE_C_COMPILER /usr/bin/gcc)
-set (CMAKE_CXX_COMPILER /usr/bin/g++)
+set(CMAKE_C_COMPILER /usr/bin/gcc CACHE STRING "")
+set(CMAKE_CXX_COMPILER /usr/bin/g++ CACHE STRING "")
 set(CMAKE_AR ar CACHE FILEPATH "" FORCE)
 set(CMAKE_RANLIB ranlib CACHE FILEPATH "" FORCE)
 set(PKG_CONFIG_EXECUTABLE pkg-config CACHE FILEPATH "" FORCE)


### PR DESCRIPTION
This enables overriding them with CMake command line variable
definitions, which is needed to use ccache.

Verified that this makes ccache work for caffe2 iOS build.